### PR TITLE
payment of transfers made user configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,12 @@ if wallet contains twice the amount if the required minimum cash liquidity, spar
 ```
 mvn jetty:run -DsavingsAddress=mgSgVGAaz7H99vLB4gAqH3f7Qr1jpcLoy2 -DminimumCash=100000000
 ```
+
+works around delays due to tx floods by using the ouputs of an incoming payment transaction for an invoice
+as inputs for te invoices transfer transaction
+while allowing malleability to break the transfer transaction
+
+default is ```true```; set to ```false``` to prevent malleability breaking transfer payments
+```
+mvn jetty:run -DuseIncomingPaymentForTransfers=true
+```

--- a/pom.xml
+++ b/pom.xml
@@ -250,5 +250,6 @@
         <walletCreationTime>1504199300</walletCreationTime>
         <savingsAddress>mgSgVGAaz7H99vLB4gAqH3f7Qr1jpcLoy2</savingsAddress>
         <minimumCash>5000000</minimumCash>
+        <useIncomingPaymentForTransfers>true</useIncomingPaymentForTransfers>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -249,6 +249,6 @@
         <walletPassphrase/>
         <walletCreationTime>1504199300</walletCreationTime>
         <savingsAddress>mgSgVGAaz7H99vLB4gAqH3f7Qr1jpcLoy2</savingsAddress>
-        <minimumCash>1000000</minimumCash>
+        <minimumCash>5000000</minimumCash>
     </properties>
 </project>

--- a/src/main/java/iuno/tdm/paymentservice/Bitcoin.java
+++ b/src/main/java/iuno/tdm/paymentservice/Bitcoin.java
@@ -320,8 +320,9 @@ public class Bitcoin implements WalletCoinsReceivedEventListener, WalletChangeEv
         inv.invoiceId(invoiceId);
         BitcoinInvoice bcInvoice = new BitcoinInvoice(invoiceId, inv, wallet.freshReceiveAddress(),
                 wallet.freshReceiveAddress(), paymentSocketIOServlet, couponRandomSeed);
-        Wallet couponWallet = bcInvoice.getCouponWallet();
-        peerGroup.addWallet(couponWallet);
+        bcInvoice.setUseIncomingPaymentForTransfers(Boolean.parseBoolean(System.getProperty("useIncomingPaymentForTransfers", "false")));
+
+        peerGroup.addWallet(bcInvoice.getCouponWallet());
 
         // add invoice to hashmaps
         invoiceHashMap.put(invoiceId, bcInvoice);


### PR DESCRIPTION
With this PR the user can decide via the new boolean parameter _useIncomingPaymentForTransfers_ if transfer payments are paid with change or with the incoming transaction paying the invoice. Default value is _true_.